### PR TITLE
fix(deploy): use JSON output for doctl deployment status

### DIFF
--- a/.claude/LEARNINGS.md
+++ b/.claude/LEARNINGS.md
@@ -77,6 +77,7 @@ useEffect(() => () => {
 | Issue | Fix |
 |-------|-----|
 | `doctl --format Name` returns `<nil>` | Use `--format Spec.Name` |
+| `doctl --format *.Phase` returns `<nil>` | Use `--output json` + jq |
 | Buildpacks prune devDeps before build | Use Dockerfile for Next.js |
 | PR comments fail | Add `permissions: pull-requests: write` |
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -298,17 +298,30 @@ jobs:
             doctl apps update $APP_ID --spec .do/app-production.yaml
           fi
 
-          # Wait for deployment
+          # Wait for deployment (use JSON output - doctl --format returns <nil> for nested fields)
           APP_ID=$(doctl apps list --format ID,Spec.Name --no-header | grep "villa-production$" | awk '{print $1}')
           for i in {1..30}; do
-            STATUS=$(doctl apps get $APP_ID --format ActiveDeployment.Phase --no-header 2>/dev/null || echo "PENDING")
-            if [ "$STATUS" = "ACTIVE" ]; then
-              APP_URL=$(doctl apps get $APP_ID --format DefaultIngress --no-header)
+            # Get app data as JSON and parse with jq
+            APP_JSON=$(doctl apps get $APP_ID --output json 2>/dev/null || echo '{}')
+
+            # Check for in-progress deployment first
+            IN_PROGRESS=$(echo "$APP_JSON" | jq -r '.in_progress_deployment.phase // empty')
+            if [ -n "$IN_PROGRESS" ]; then
+              echo "Building: $IN_PROGRESS ($i/30)"
+              sleep 10
+              continue
+            fi
+
+            # Check active deployment status
+            ACTIVE_PHASE=$(echo "$APP_JSON" | jq -r '.active_deployment.phase // empty')
+            if [ "$ACTIVE_PHASE" = "ACTIVE" ]; then
+              APP_URL=$(echo "$APP_JSON" | jq -r '.default_ingress // empty')
               echo "url=https://${APP_URL}" >> $GITHUB_OUTPUT
               echo "✅ Production deployed: https://${APP_URL}"
               exit 0
             fi
-            echo "Status: $STATUS ($i/30)"
+
+            echo "Status: ${ACTIVE_PHASE:-PENDING} ($i/30)"
             sleep 10
           done
           echo "❌ Deployment timeout"


### PR DESCRIPTION
## Problem

Production deployment times out with `Status: <nil>` repeated 30 times:

```
Status: <nil> (1/30)
Status: <nil> (2/30)
...
Status: <nil> (30/30)
❌ Deployment timeout
```

## Root Cause

`doctl apps get $APP_ID --format ActiveDeployment.Phase` returns `<nil>` for nested fields. This is the same class of bug as `--format Name` returning `<nil>`.

## Solution

Use JSON output with jq parsing:

```bash
APP_JSON=$(doctl apps get $APP_ID --output json)
ACTIVE_PHASE=$(echo "$APP_JSON" | jq -r '.active_deployment.phase // empty')
```

Also added in-progress deployment detection for better build visibility:
```
Building: DEPLOYING (5/30)
```

## Changes

- `.github/workflows/deploy.yml` - Use JSON output + jq for deployment status
- `.claude/LEARNINGS.md` - Document the `*.Phase` quirk

## Test Plan

- [ ] Merge to main triggers production deploy
- [ ] Status shows actual phase (BUILDING, DEPLOYING, ACTIVE)
- [ ] Deployment completes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)