### PR TITLE
fix: avatar btoa Unicode encoding for DiceBear SVGs

### DIFF
--- a/src/components/sdk/AvatarPreview.tsx
+++ b/src/components/sdk/AvatarPreview.tsx
@@ -31,7 +31,7 @@ export function AvatarPreview({
   const dataUrl = useMemo(() => {
     if (!walletAddress) return ''
     const svgString = generateAvatarFromSelection(walletAddress, selection, variant)
-    return `data:image/svg+xml;base64,${btoa(svgString)}`
+    return `data:image/svg+xml;base64,${btoa(unescape(encodeURIComponent(svgString)))}`
   }, [walletAddress, selection, variant])
 
   if (!dataUrl) {

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -59,7 +59,7 @@ export function Avatar({ src, walletAddress, name, size = 'md', className }: Ava
   // Handle AvatarConfig - generate SVG from DiceBear
   if (src && typeof src === 'object' && 'selection' in src && walletAddress) {
     const svgString = generateAvatarFromSelection(walletAddress, src.selection, src.variant)
-    const dataUrl = `data:image/svg+xml;base64,${btoa(svgString)}`
+    const dataUrl = `data:image/svg+xml;base64,${btoa(unescape(encodeURIComponent(svgString)))}`
     return (
       <img
         src={dataUrl}


### PR DESCRIPTION
## Summary
Fixes Unicode encoding issue when converting DiceBear SVG avatars to base64 data URIs. The `btoa()` function doesn't handle multi-byte Unicode characters correctly, causing avatar images to fail rendering.

## Changes
- Updated `src/components/sdk/AvatarPreview.tsx` to properly encode Unicode characters
- Updated `src/components/ui/avatar.tsx` to handle multi-byte character encoding

## Test Plan
- [ ] Load avatar with standard ASCII characters
- [ ] Load avatar with Unicode characters (e.g., emoji, accented letters)
- [ ] Verify SVG data URI renders correctly in preview
- [ ] Check avatar displays on profile screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)