### PR TITLE
fix(deploy): force rebuild to prevent stale deployments

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -494,6 +494,10 @@ jobs:
           else
             echo "📦 Updating staging app..."
             doctl apps update $APP_ID --spec .do/app-staging.yaml
+
+            # Force rebuild to ensure new code is deployed (fixes cache issues)
+            echo "🔨 Forcing rebuild with --force-rebuild..."
+            doctl apps create-deployment $APP_ID --force-rebuild --wait=false
           fi
 
           # Wait for deployment
@@ -696,6 +700,10 @@ jobs:
           else
             echo "📦 Updating production app..."
             doctl apps update $APP_ID --spec .do/app-production.yaml
+
+            # Force rebuild to ensure new code is deployed (fixes cache issues)
+            echo "🔨 Forcing rebuild with --force-rebuild..."
+            doctl apps create-deployment $APP_ID --force-rebuild --wait=false
           fi
 
           # Wait for deployment


### PR DESCRIPTION
## Summary

DigitalOcean App Platform caches builds. The command `doctl apps update` only updates the app spec - it doesn't trigger a rebuild if the source hasn't changed from DO's perspective.

This caused **staging to serve stale code while reporting successful deploys**.

**Root cause discovered:** The buildId stayed `2fyhwY39M6wY_DTgqVJFX` across 10+ "successful" deploys. The SSR/hydration fix committed to main was never actually built.

## Changes

- Add `doctl apps create-deployment --force-rebuild` after `doctl apps update` for both staging and production
- Document the pattern in LEARNINGS.md for future reference

## Test plan

- [ ] Merge this PR
- [ ] Push any commit to main
- [ ] Verify staging buildId changes (check `/_next/static/<buildId>` in page source)
- [ ] Run E2E tests against beta.villa.cash - returning user flow should work

## Session Analysis

This bug wasted ~2 hours of debugging. The SSR fix was correct but never deployed:
- 10+ deploy attempts that "succeeded" but served old code
- E2E tests kept failing on staging with identical errors
- Only discovered by checking buildId in deployed JS bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)