### PR TITLE
feat(claude): multi-developer preferences + CI context validation

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -11,7 +11,22 @@ Privacy-first passkey authentication on **Base** network. Porto SDK + Villa them
 
 **Orchestrator Identity:** Read [SYSTEM_PROMPT.md](SYSTEM_PROMPT.md) for partnership model
 **Philosophy:** Read [MANIFESTO.md](MANIFESTO.md) for repo-as-truth principles
-**Test Context:** `pnpm test:context` validates all prompts load correctly
+**Test Context:** `pnpm context:validate` (also runs in CI)
+
+---
+
+## Multi-Developer Preferences
+
+**Shared** (checked in): `.claude/shared/defaults.json`
+**Local** (gitignored): `.claude/local/preferences.json`
+
+```bash
+pnpm prefs:show      # View effective preferences
+pnpm prefs:report    # Full report with pending questions
+cp .claude/local/preferences.template.json .claude/local/preferences.json  # Setup
+```
+
+Claude learns your preferences over time. See [shared/preferences.schema.ts](shared/preferences.schema.ts) for options.
 
 ---
 

--- a/.claude/local/.gitkeep
+++ b/.claude/local/.gitkeep
@@ -1,0 +1,9 @@
+# This directory contains per-developer preferences (gitignored)
+#
+# Files:
+#   preferences.json  - Your personal preference overrides
+#   learning.json     - What Claude has learned about working with you
+#
+# To set up your local preferences:
+#   cp ../.claude/local/preferences.template.json preferences.json
+#   # Edit preferences.json with your preferences

--- a/.claude/local/preferences.template.json
+++ b/.claude/local/preferences.template.json
@@ -1,0 +1,28 @@
+{
+  "_comment": "Copy this file to preferences.json and customize. Only include fields you want to override.",
+  "_docs": "See .claude/shared/preferences.schema.ts for full schema documentation.",
+
+  "communication": {
+    "verbosity": "concise",
+    "explanations": "brief",
+    "tone": "direct",
+    "technicalLevel": "expert"
+  },
+
+  "workflow": {
+    "parallelism": "aggressive",
+    "autonomy": "high",
+    "checkpoints": "milestone",
+    "proactiveSuggestions": true
+  },
+
+  "focus": {
+    "areas": ["frontend", "sdk"],
+    "currentFocus": "sprint-4"
+  },
+
+  "learning": {
+    "enableLearning": true,
+    "allowPreferenceQuestions": true
+  }
+}

--- a/.claude/rag/preferences.ts
+++ b/.claude/rag/preferences.ts
@@ -1,0 +1,251 @@
+/**
+ * Preferences Loader
+ *
+ * Loads and merges developer preferences from:
+ * 1. Shared defaults (.claude/shared/defaults.json)
+ * 2. Local overrides (.claude/local/preferences.json)
+ * 3. Learned preferences (.claude/local/learning.json)
+ */
+
+import { readFileSync, writeFileSync, existsSync } from 'fs';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import type {
+  DeveloperPreferences,
+  LearningState,
+  PreferenceQuestion,
+  PreferenceObservation,
+} from '../shared/preferences.schema.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const CLAUDE_DIR = dirname(__dirname);
+
+const SHARED_DEFAULTS_PATH = join(CLAUDE_DIR, 'shared', 'defaults.json');
+const LOCAL_PREFS_PATH = join(CLAUDE_DIR, 'local', 'preferences.json');
+const LEARNING_PATH = join(CLAUDE_DIR, 'local', 'learning.json');
+
+/**
+ * Deep merge two objects, with source overriding target
+ */
+function deepMerge<T extends Record<string, unknown>>(
+  target: T,
+  source: Partial<T>
+): T {
+  const result = { ...target };
+  for (const key in source) {
+    if (source[key] !== undefined) {
+      if (
+        typeof source[key] === 'object' &&
+        source[key] !== null &&
+        !Array.isArray(source[key])
+      ) {
+        result[key] = deepMerge(
+          (target[key] as Record<string, unknown>) || {},
+          source[key] as Record<string, unknown>
+        ) as T[typeof key];
+      } else {
+        result[key] = source[key] as T[typeof key];
+      }
+    }
+  }
+  return result;
+}
+
+/**
+ * Load shared defaults
+ */
+export function loadSharedDefaults(): DeveloperPreferences {
+  const content = readFileSync(SHARED_DEFAULTS_PATH, 'utf-8');
+  return JSON.parse(content);
+}
+
+/**
+ * Load local preferences if they exist
+ */
+export function loadLocalPreferences(): Partial<DeveloperPreferences> | null {
+  if (!existsSync(LOCAL_PREFS_PATH)) {
+    return null;
+  }
+  const content = readFileSync(LOCAL_PREFS_PATH, 'utf-8');
+  return JSON.parse(content);
+}
+
+/**
+ * Load learning state if it exists
+ */
+export function loadLearningState(): LearningState {
+  if (!existsSync(LEARNING_PATH)) {
+    return {
+      pendingQuestions: [],
+      answeredQuestions: [],
+      observations: [],
+      confirmedPreferences: {},
+    };
+  }
+  const content = readFileSync(LEARNING_PATH, 'utf-8');
+  return JSON.parse(content);
+}
+
+/**
+ * Save learning state
+ */
+export function saveLearningState(state: LearningState): void {
+  writeFileSync(LEARNING_PATH, JSON.stringify(state, null, 2));
+}
+
+/**
+ * Get effective preferences (merged: defaults + local + learned)
+ */
+export function getEffectivePreferences(): DeveloperPreferences {
+  const defaults = loadSharedDefaults();
+  const local = loadLocalPreferences();
+  const learning = loadLearningState();
+
+  // Start with defaults
+  let prefs = { ...defaults };
+
+  // Apply local overrides
+  if (local) {
+    prefs = deepMerge(prefs, local);
+  }
+
+  // Apply learned preferences (highest priority for confirmed ones)
+  if (learning.confirmedPreferences) {
+    prefs = deepMerge(prefs, learning.confirmedPreferences as Partial<DeveloperPreferences>);
+  }
+
+  return prefs;
+}
+
+/**
+ * Add a question for the developer
+ */
+export function addQuestion(question: Omit<PreferenceQuestion, 'id' | 'createdAt'>): void {
+  const state = loadLearningState();
+  const newQuestion: PreferenceQuestion = {
+    ...question,
+    id: `q-${Date.now()}`,
+    createdAt: new Date().toISOString(),
+  };
+  state.pendingQuestions.push(newQuestion);
+  saveLearningState(state);
+}
+
+/**
+ * Record an observation about developer preferences
+ */
+export function addObservation(observation: Omit<PreferenceObservation, 'id' | 'observedAt'>): void {
+  const state = loadLearningState();
+  const newObs: PreferenceObservation = {
+    ...observation,
+    id: `obs-${Date.now()}`,
+    observedAt: new Date().toISOString(),
+  };
+  state.observations.push(newObs);
+  saveLearningState(state);
+}
+
+/**
+ * Get pending questions to ask
+ */
+export function getPendingQuestions(): PreferenceQuestion[] {
+  const state = loadLearningState();
+  return state.pendingQuestions;
+}
+
+/**
+ * Mark a question as answered
+ */
+export function answerQuestion(questionId: string, answer: string): void {
+  const state = loadLearningState();
+  const idx = state.pendingQuestions.findIndex((q) => q.id === questionId);
+  if (idx !== -1) {
+    const question = state.pendingQuestions.splice(idx, 1)[0];
+    state.answeredQuestions.push({
+      ...question,
+      answer,
+      answeredAt: new Date().toISOString(),
+    });
+    saveLearningState(state);
+  }
+}
+
+/**
+ * Confirm an observation as a preference
+ */
+export function confirmObservation(
+  observationId: string,
+  preferencePath: string,
+  value: unknown
+): void {
+  const state = loadLearningState();
+  const obs = state.observations.find((o) => o.id === observationId);
+  if (obs) {
+    obs.confirmedByUser = true;
+    // Set nested preference using path like "communication.verbosity"
+    const parts = preferencePath.split('.');
+    let current: Record<string, unknown> = state.confirmedPreferences as Record<string, unknown>;
+    for (let i = 0; i < parts.length - 1; i++) {
+      if (!current[parts[i]]) {
+        current[parts[i]] = {};
+      }
+      current = current[parts[i]] as Record<string, unknown>;
+    }
+    current[parts[parts.length - 1]] = value;
+    saveLearningState(state);
+  }
+}
+
+/**
+ * Generate a preferences report
+ */
+export function generatePreferencesReport(): string {
+  const defaults = loadSharedDefaults();
+  const local = loadLocalPreferences();
+  const learning = loadLearningState();
+  const effective = getEffectivePreferences();
+
+  let report = '# Developer Preferences Report\n\n';
+
+  report += '## Effective Preferences\n\n';
+  report += '```json\n' + JSON.stringify(effective, null, 2) + '\n```\n\n';
+
+  report += '## Sources\n\n';
+  report += `- Shared defaults: ✅ Loaded\n`;
+  report += `- Local overrides: ${local ? '✅ Loaded' : '❌ Not found (using defaults)'}\n`;
+  report += `- Learned preferences: ${Object.keys(learning.confirmedPreferences).length} confirmed\n`;
+  report += `- Pending questions: ${learning.pendingQuestions.length}\n`;
+  report += `- Observations: ${learning.observations.length}\n`;
+
+  if (learning.pendingQuestions.length > 0) {
+    report += '\n## Pending Questions\n\n';
+    learning.pendingQuestions.forEach((q) => {
+      report += `### ${q.question}\n`;
+      if (q.context) report += `_Context: ${q.context}_\n`;
+      if (q.options) report += `Options: ${q.options.join(', ')}\n`;
+      report += `Priority: ${q.priority} | Category: ${q.category}\n\n`;
+    });
+  }
+
+  return report;
+}
+
+// CLI
+if (process.argv[1]?.includes('preferences.ts')) {
+  const command = process.argv[2];
+
+  switch (command) {
+    case 'show':
+      console.log(JSON.stringify(getEffectivePreferences(), null, 2));
+      break;
+    case 'questions':
+      console.log(JSON.stringify(getPendingQuestions(), null, 2));
+      break;
+    case 'report':
+      console.log(generatePreferencesReport());
+      break;
+    default:
+      console.log('Usage: npx tsx .claude/rag/preferences.ts [show|questions|report]');
+  }
+}

--- a/.claude/shared/defaults.json
+++ b/.claude/shared/defaults.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "./preferences.schema.json",
+  "_comment": "Default preferences for all Villa developers. Override in .claude/local/preferences.json",
+
+  "communication": {
+    "verbosity": "adaptive",
+    "explanations": "brief",
+    "tone": "direct",
+    "technicalLevel": "expert"
+  },
+
+  "workflow": {
+    "parallelism": "aggressive",
+    "autonomy": "high",
+    "checkpoints": "milestone",
+    "proactiveSuggestions": true
+  },
+
+  "models": {
+    "default": "sonnet",
+    "agents": {
+      "spec": "opus",
+      "architect": "opus",
+      "product": "opus",
+      "build": "sonnet",
+      "design": "sonnet",
+      "review": "sonnet",
+      "test": "haiku",
+      "ops": "haiku",
+      "explore": "haiku"
+    }
+  },
+
+  "focus": {
+    "areas": [],
+    "currentFocus": null,
+    "ownedPaths": []
+  },
+
+  "learning": {
+    "enableLearning": true,
+    "shareAnonymousPatterns": true,
+    "allowPreferenceQuestions": true
+  }
+}

--- a/.claude/shared/preferences.schema.ts
+++ b/.claude/shared/preferences.schema.ts
@@ -1,0 +1,109 @@
+/**
+ * Developer Preferences Schema
+ *
+ * Defines the structure for both shared defaults and local overrides.
+ * Shared defaults are checked in; local preferences are gitignored.
+ */
+
+export interface DeveloperPreferences {
+  /**
+   * How Claude should communicate with this developer
+   */
+  communication: {
+    /** How verbose responses should be */
+    verbosity: 'concise' | 'detailed' | 'adaptive';
+    /** How much to explain code changes */
+    explanations: 'brief' | 'thorough' | 'on-request';
+    /** Communication tone */
+    tone: 'direct' | 'friendly' | 'professional';
+    /** Whether to use technical jargon freely */
+    technicalLevel: 'beginner' | 'intermediate' | 'expert';
+  };
+
+  /**
+   * How Claude should work with this developer
+   */
+  workflow: {
+    /** How aggressively to parallelize work */
+    parallelism: 'aggressive' | 'conservative' | 'ask';
+    /** How much autonomy Claude should take */
+    autonomy: 'high' | 'medium' | 'low';
+    /** How often to check in with progress */
+    checkpoints: 'frequent' | 'milestone' | 'minimal';
+    /** Whether to proactively suggest improvements */
+    proactiveSuggestions: boolean;
+  };
+
+  /**
+   * Model preferences for different tasks
+   */
+  models: {
+    /** Default model when not specified */
+    default: 'opus' | 'sonnet' | 'haiku';
+    /** Per-agent overrides */
+    agents: Partial<Record<string, 'opus' | 'sonnet' | 'haiku'>>;
+  };
+
+  /**
+   * Areas this developer focuses on
+   */
+  focus: {
+    /** Primary areas of expertise/interest */
+    areas: string[];
+    /** Current sprint or project focus */
+    currentFocus?: string;
+    /** Files/directories this dev owns */
+    ownedPaths?: string[];
+  };
+
+  /**
+   * Learning and adaptation settings
+   */
+  learning: {
+    /** Allow Claude to learn from interactions */
+    enableLearning: boolean;
+    /** Share anonymized patterns to improve shared defaults */
+    shareAnonymousPatterns: boolean;
+    /** Allow Claude to ask clarifying questions about preferences */
+    allowPreferenceQuestions: boolean;
+  };
+}
+
+/**
+ * A question Claude wants to ask the developer
+ */
+export interface PreferenceQuestion {
+  id: string;
+  question: string;
+  context?: string;
+  options?: string[];
+  category: keyof DeveloperPreferences;
+  priority: 'high' | 'medium' | 'low';
+  createdAt: string;
+}
+
+/**
+ * An observation Claude made about developer preferences
+ */
+export interface PreferenceObservation {
+  id: string;
+  pattern: string;
+  inference: string;
+  confidence: number; // 0-1
+  observedAt: string;
+  confirmedByUser?: boolean;
+}
+
+/**
+ * Local learning state (gitignored)
+ */
+export interface LearningState {
+  /** Pending questions to ask */
+  pendingQuestions: PreferenceQuestion[];
+  /** Questions that have been answered */
+  answeredQuestions: Array<PreferenceQuestion & { answer: string; answeredAt: string }>;
+  /** Observations from interactions */
+  observations: PreferenceObservation[];
+  /** Preferences confirmed from observations */
+  confirmedPreferences: Partial<DeveloperPreferences>;
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,30 @@ on:
     branches: [main]
 
 jobs:
+  validate-context:
+    name: Validate Agent Context
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Validate agent definitions
+        run: pnpm context:validate
+
+      - name: Generate context report
+        run: pnpm context:report
+
   validate-specs:
     name: Validate Specifications
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,10 @@ certificates/
 # Coordination state (runtime, per-machine)
 .claude/coordination/
 
+# Local developer preferences (per-developer)
+.claude/local/preferences.json
+.claude/local/learning.json
+
 # ngrok config (per-machine)
 .ngrok.yml
 

--- a/package.json
+++ b/package.json
@@ -54,7 +54,10 @@
     "test:api": "pnpm --filter @villa/api test",
     "test:context": "vitest run .claude/rag/context.test.ts",
     "context:validate": "pnpm --filter @villa/web exec tsx ../../.claude/rag/loader.ts validate",
-    "context:report": "pnpm --filter @villa/web exec tsx ../../.claude/rag/loader.ts report"
+    "context:report": "pnpm --filter @villa/web exec tsx ../../.claude/rag/loader.ts report",
+    "prefs:show": "pnpm --filter @villa/web exec tsx ../../.claude/rag/preferences.ts show",
+    "prefs:questions": "pnpm --filter @villa/web exec tsx ../../.claude/rag/preferences.ts questions",
+    "prefs:report": "pnpm --filter @villa/web exec tsx ../../.claude/rag/preferences.ts report"
   },
   "devDependencies": {
     "@types/node": "25.0.3",


### PR DESCRIPTION
## Summary

Implements a system for multiple developers to work with Claude while sharing project configs and maintaining personal preferences.

## Changes

### CI Integration
- Added `validate-context` job to CI pipeline
- Runs `pnpm context:validate` on every PR
- Generates context report for visibility

### Multi-Developer Preferences

| Type | Location | Purpose |
|------|----------|---------|
| Shared | `.claude/shared/defaults.json` | Default prefs for all devs |
| Schema | `.claude/shared/preferences.schema.ts` | TypeScript types |
| Local | `.claude/local/preferences.json` | Personal overrides (gitignored) |
| Learning | `.claude/local/learning.json` | Claude's observations (gitignored) |

### Commands

```bash
pnpm prefs:show      # View effective (merged) preferences
pnpm prefs:report    # Full report with pending questions
```

### Preference Categories

- **communication**: verbosity, explanations, tone, technicalLevel
- **workflow**: parallelism, autonomy, checkpoints, proactiveSuggestions
- **models**: default model, per-agent overrides
- **focus**: areas, currentFocus, ownedPaths
- **learning**: enableLearning, allowPreferenceQuestions

### Learning System

Claude can:
1. Observe patterns in how you work
2. Ask clarifying questions about preferences
3. Store learned preferences locally
4. Apply them in future sessions

## Test plan

- [x] `pnpm prefs:show` displays merged preferences
- [x] `pnpm prefs:report` generates full report
- [x] `pnpm context:validate` still passes
- [x] Local files correctly gitignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)