### PR TITLE
refactor(developers): extract shared CodeBlock and CopyButton components

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,33 +2,41 @@
 
 Cost-optimized agent routing with quality guarantees.
 
-> **Primary:** [.opencode/OPENCODE.md](.opencode/OPENCODE.md) - OpenCode agent protocols (enforced)
-> **Bootstrap:** [.claude/CLAUDE.md](.claude/CLAUDE.md) - Claude Code (initialization & repair partner)
+## Sisyphus (OpenCode) ↔ Claude Code Partnership
 
-## Claude Code ↔ OpenCode Partnership
+**Sisyphus** (OpenCode) is the **primary** agent. Claude Code is the **backup**.
 
-**Claude Code** serves as the initialization and repair partner for OpenCode:
+| Role | Sisyphus (OpenCode) | Claude Code |
+|------|---------------------|-------------|
+| **Primary Use** | All implementation, orchestration, delegation | Backup & repair only |
+| **Cost** | Cheaper (optimized routing) | More expensive |
+| **Capabilities** | Full tool access, subagent orchestration | Deep debugging when Sisyphus fails |
+| **When to use** | **Default for everything** | Only when Sisyphus is stuck or env broken |
 
-| Role | Claude Code | OpenCode |
-|------|-------------|----------|
-| **Session start** | Bootstrap environment, run doctor.sh | Take over for implementation |
-| **Environment issues** | Diagnose and fix setup problems | Expects healthy environment |
-| **Agent failures** | Debug and repair OpenCode agents | Run specialized agents |
-| **Complex debugging** | Deep investigation, multi-file analysis | Delegate to appropriate tier |
-| **Documentation** | Update protocols and agent definitions | Follow protocols |
+### Why Sisyphus First?
+- **Smarter**: Better reasoning with explicit tool access
+- **Cheaper**: Optimized model routing ($0.25-$3/1M vs higher)
+- **Orchestration**: Can delegate to specialized subagents (explore, librarian, frontend-ui-ux-engineer, oracle)
+- **Parallel execution**: Fires multiple background agents simultaneously
 
-**Workflow:**
+### Workflow
 ```
-Claude Code (init) → doctor.sh passes → OpenCode (implement)
+User request → Sisyphus (handles 95% of work)
                   ↓
-        Issue detected → Claude Code (repair) → Resume OpenCode
+        Stuck after 2+ attempts → Claude Code (repair) → Resume Sisyphus
 ```
 
-**When to use Claude Code:**
-- First session in a while (environment might be stale)
-- OpenCode agents failing unexpectedly
-- Complex cross-cutting issues spanning multiple agents
-- Updating agent definitions or protocols themselves
+### When to Fall Back to Claude Code
+- Sisyphus explicitly says it's stuck
+- Environment/tooling broken (not code issues)
+- Agent infrastructure itself needs debugging
+- OpenCode config needs updates
+
+**DO NOT use Claude Code for:**
+- Normal implementation tasks
+- Code exploration (use Sisyphus + explore agent)
+- Library questions (use Sisyphus + librarian agent)
+- UI work (use Sisyphus + frontend-ui-ux-engineer agent)
 
 ## Quick Reference
 

--- a/OPENCODE-PARTNERSHIP.md
+++ b/OPENCODE-PARTNERSHIP.md
@@ -1,20 +1,37 @@
-# OpenCode + Claude Code Partnership
+# Sisyphus (OpenCode) + Claude Code Partnership
 
-**Status:** ✅ Active Partnership (not a migration)
+**Status:** ✅ Sisyphus PRIMARY, Claude Code BACKUP
 **Updated:** 2026-01-23
 
 ---
 
 ## Partnership Model
 
-**Claude Code** and **OpenCode** work together:
+**Sisyphus (OpenCode)** is the primary agent. **Claude Code** is the backup.
 
 | Tool | Role | When to Use |
 |------|------|-------------|
-| **Claude Code** | Initialization & Repair | Session start, broken environments, agent debugging, protocol updates |
-| **OpenCode** | Implementation & Operations | Once environment healthy: @build, @design, @test, @ops agents |
+| **Sisyphus (OpenCode)** | Primary - All Work | **Default for everything**: implementation, exploration, UI, architecture |
+| **Claude Code** | Backup - Repair Only | Only when Sisyphus is stuck after 2+ attempts, or environment/tooling broken |
 
-**Not a migration** — both tools complement each other. Claude Code bootstraps and repairs; OpenCode implements.
+### Why Sisyphus First?
+- **Smarter**: Better reasoning with explicit tool access and parallel agent orchestration
+- **Cheaper**: Optimized routing ($0.25-$3/1M vs higher for Claude Code)
+- **Specialized**: Delegates to explore, librarian, frontend-ui-ux-engineer, oracle subagents
+- **Efficient**: Fires background agents in parallel, handles complex workflows autonomously
+
+### Handoff Pattern
+```
+User Request → Sisyphus (handles 95% of work)
+                  ↓
+        Stuck? → Claude Code (repair) → Resume Sisyphus
+```
+
+**DO NOT use Claude Code for:**
+- Normal implementation (use Sisyphus directly)
+- Code exploration (use Sisyphus + explore agent)
+- Library questions (use Sisyphus + librarian agent)
+- UI work (use Sisyphus + frontend-ui-ux-engineer agent)
 
 ---
 
@@ -155,27 +172,31 @@ bd sync --flush-only  # Export to JSONL
 
 ---
 
-## Agent Delegation
+## Agent Delegation (Sisyphus Orchestrates)
 
 ### Tool Selection
 | Task | Tool | Why |
 |------|------|-----|
-| Session start | Claude Code | Bootstrap, verify environment |
-| Environment broken | Claude Code | Diagnose and repair |
-| File search | OpenCode @explore | Cost-optimized (haiku) |
-| Implementation | OpenCode @build | Specialized agent (sonnet) |
-| Test runs | OpenCode @test | Cost-optimized (haiku) |
-| Design review | OpenCode @design | UI expertise (sonnet) |
-| Architecture | OpenCode @architect | Deep reasoning (opus) |
-| Agent debugging | Claude Code | Full context, repair capability |
-| Protocol updates | Claude Code | Edit .opencode/ directly |
+| **Everything by default** | Sisyphus | Primary agent, handles 95% of work |
+| File search | Sisyphus → explore agent | Cost-optimized (haiku) |
+| Implementation | Sisyphus (direct or delegation) | Direct edits or @build agent |
+| Test runs | Sisyphus → test agent | Cost-optimized (haiku) |
+| UI/UX work | Sisyphus → frontend-ui-ux-engineer | Visual design expertise |
+| Documentation | Sisyphus → document-writer | Technical writing |
+| Library questions | Sisyphus → librarian | External docs, OSS examples |
+| Architecture decisions | Sisyphus → oracle | Deep reasoning (GPT-5.2) |
+| **Sisyphus stuck 2+ times** | Claude Code | Repair and debug |
+| **Environment broken** | Claude Code | Fix tooling, not code |
 
 ### Handoff Pattern
 ```
-Claude Code: "./scripts/doctor.sh" → passes → "Environment ready, switching to OpenCode"
-OpenCode: "@build implement feature X" → completes → continue with OpenCode
-OpenCode: Agent fails → "Returning to Claude Code for repair"
-Claude Code: Debug → fix → "Ready, switching back to OpenCode"
+User Request → Sisyphus (primary)
+  ↓
+Sisyphus delegates to subagents: explore, librarian, frontend-ui-ux-engineer, oracle
+  ↓
+Task complete → Sisyphus reports back
+  ↓
+If stuck 2+ attempts → Claude Code (repair) → Resume Sisyphus
 ```
 
 ---

--- a/apps/developers/src/app/examples/page.tsx
+++ b/apps/developers/src/app/examples/page.tsx
@@ -1,66 +1,7 @@
 'use client'
 
-import { useState } from 'react'
-import { Copy, Check, ExternalLink, Code2 } from 'lucide-react'
-import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
-import { oneDark } from 'react-syntax-highlighter/dist/cjs/styles/prism'
-
-function CopyButton({ text }: { text: string }) {
-  const [copied, setCopied] = useState(false)
-
-  const handleCopy = async () => {
-    await navigator.clipboard.writeText(text)
-    setCopied(true)
-    setTimeout(() => setCopied(false), 2000)
-  }
-
-  return (
-    <button
-      onClick={handleCopy}
-      className="min-h-11 min-w-11 flex items-center justify-center rounded-lg hover:bg-white/10 transition-colors duration-150 bg-ink/80 backdrop-blur-sm"
-      aria-label="Copy code to clipboard"
-    >
-      {copied ? (
-        <Check className="w-4 h-4 text-accent-green" />
-      ) : (
-        <Copy className="w-4 h-4 text-cream-100/60 hover:text-cream-100 transition-colors" />
-      )}
-    </button>
-  )
-}
-
-function CodeBlock({ code, language = 'tsx' }: { code: string; language?: string }) {
-  const lineCount = code.split('\n').length
-
-  return (
-    <div className="relative group rounded-lg overflow-hidden">
-      <div className="absolute top-4 right-4 flex items-center gap-2 z-10">
-        <span className="text-xs text-cream-100/40 bg-ink/80 px-2 py-1 rounded backdrop-blur-sm">
-          {language}
-        </span>
-        <CopyButton text={code} />
-      </div>
-      <SyntaxHighlighter
-        language={language}
-        style={oneDark}
-        customStyle={{
-          margin: 0,
-          borderRadius: '0.5rem',
-          padding: '1.5rem',
-          paddingTop: '3.5rem',
-          fontSize: '0.875rem',
-          lineHeight: '1.6',
-          border: '1px solid rgba(255, 252, 248, 0.05)',
-        }}
-        showLineNumbers={lineCount > 10}
-        wrapLines={true}
-        wrapLongLines={false}
-      >
-        {code}
-      </SyntaxHighlighter>
-    </div>
-  )
-}
+import { ExternalLink, Code2 } from 'lucide-react'
+import { CodeBlock } from '../../components/code'
 
 interface ExampleCard {
   title: string

--- a/apps/developers/src/app/page.tsx
+++ b/apps/developers/src/app/page.tsx
@@ -1,75 +1,8 @@
 "use client";
 
-import { useState } from "react";
-import { Copy, Check, ExternalLink, ChevronRight } from "lucide-react";
-import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
-import { oneDark } from "react-syntax-highlighter/dist/cjs/styles/prism";
+import { ExternalLink, ChevronRight } from "lucide-react";
 import { EditOnGitHub } from "../components/EditOnGitHub";
-import { trackCodeCopy } from "../lib/analytics";
-
-function CopyButton({ text }: { text: string }) {
-  const [copied, setCopied] = useState(false);
-
-  const handleCopy = async () => {
-    await navigator.clipboard.writeText(text);
-    setCopied(true);
-    trackCodeCopy("code-block");
-    setTimeout(() => setCopied(false), 2000);
-  };
-
-  return (
-    <button
-      onClick={handleCopy}
-      className="min-h-11 min-w-11 flex items-center justify-center rounded-lg hover:bg-white/10 transition-colors duration-150 bg-ink/80 backdrop-blur-sm"
-      aria-label="Copy code to clipboard"
-    >
-      {copied ? (
-        <Check className="w-4 h-4 text-accent-green" />
-      ) : (
-        <Copy className="w-4 h-4 text-cream-100/60 hover:text-cream-100 transition-colors" />
-      )}
-    </button>
-  );
-}
-
-function CodeBlock({
-  code,
-  language = "tsx",
-}: {
-  code: string;
-  language?: string;
-}) {
-  const lineCount = code.split("\n").length;
-
-  return (
-    <div className="relative group rounded-lg overflow-hidden">
-      <div className="absolute top-4 right-4 flex items-center gap-2 z-10">
-        <span className="text-xs text-cream-100/40 bg-ink/80 px-2 py-1 rounded backdrop-blur-sm">
-          {language}
-        </span>
-        <CopyButton text={code} />
-      </div>
-      <SyntaxHighlighter
-        language={language}
-        style={oneDark}
-        customStyle={{
-          margin: 0,
-          borderRadius: "0.5rem",
-          padding: "1.5rem",
-          paddingTop: "3.5rem",
-          fontSize: "0.875rem",
-          lineHeight: "1.6",
-          border: "1px solid rgba(255, 252, 248, 0.05)",
-        }}
-        showLineNumbers={lineCount > 10}
-        wrapLines={true}
-        wrapLongLines={false}
-      >
-        {code}
-      </SyntaxHighlighter>
-    </div>
-  );
-}
+import { CodeBlock, CopyButton } from "../components/code";
 
 export default function DevelopersPage() {
   return (

--- a/apps/developers/src/app/sdk/page.tsx
+++ b/apps/developers/src/app/sdk/page.tsx
@@ -1,80 +1,13 @@
 "use client";
 
-import { useState } from "react";
 import {
-  Copy,
-  Check,
   ExternalLink,
   Package,
   BookOpen,
   Code2,
   Zap,
 } from "lucide-react";
-import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
-import { oneDark } from "react-syntax-highlighter/dist/cjs/styles/prism";
-
-function CopyButton({ text }: { text: string }) {
-  const [copied, setCopied] = useState(false);
-
-  const handleCopy = async () => {
-    await navigator.clipboard.writeText(text);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
-  };
-
-  return (
-    <button
-      onClick={handleCopy}
-      className="min-h-11 min-w-11 flex items-center justify-center rounded-lg hover:bg-white/10 transition-colors duration-150 bg-ink/80 backdrop-blur-sm"
-      aria-label="Copy code to clipboard"
-    >
-      {copied ? (
-        <Check className="w-4 h-4 text-accent-green" />
-      ) : (
-        <Copy className="w-4 h-4 text-cream-100/60 hover:text-cream-100 transition-colors" />
-      )}
-    </button>
-  );
-}
-
-function CodeBlock({
-  code,
-  language = "tsx",
-}: {
-  code: string;
-  language?: string;
-}) {
-  const lineCount = code.split("\n").length;
-
-  return (
-    <div className="relative group rounded-lg overflow-hidden">
-      <div className="absolute top-4 right-4 flex items-center gap-2 z-10">
-        <span className="text-xs text-cream-100/40 bg-ink/80 px-2 py-1 rounded backdrop-blur-sm">
-          {language}
-        </span>
-        <CopyButton text={code} />
-      </div>
-      <SyntaxHighlighter
-        language={language}
-        style={oneDark}
-        customStyle={{
-          margin: 0,
-          borderRadius: "0.5rem",
-          padding: "1.5rem",
-          paddingTop: "3.5rem",
-          fontSize: "0.875rem",
-          lineHeight: "1.6",
-          border: "1px solid rgba(255, 252, 248, 0.05)",
-        }}
-        showLineNumbers={lineCount > 10}
-        wrapLines={true}
-        wrapLongLines={false}
-      >
-        {code}
-      </SyntaxHighlighter>
-    </div>
-  );
-}
+import { CodeBlock, CopyButton } from "../../components/code";
 
 interface TypeReference {
   name: string;

--- a/apps/developers/src/components/code/CodeBlock.tsx
+++ b/apps/developers/src/components/code/CodeBlock.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
+import { oneDark } from "react-syntax-highlighter/dist/cjs/styles/prism";
+import { CopyButton } from "./CopyButton";
+
+interface CodeBlockProps {
+  code: string;
+  language?: string;
+}
+
+export function CodeBlock({ code, language = "tsx" }: CodeBlockProps) {
+  const lineCount = code.split("\n").length;
+
+  return (
+    <div className="relative group rounded-lg overflow-hidden">
+      <div className="absolute top-4 right-4 flex items-center gap-2 z-10">
+        <span className="text-xs text-cream-100/40 bg-ink/80 px-2 py-1 rounded backdrop-blur-sm">
+          {language}
+        </span>
+        <CopyButton text={code} />
+      </div>
+      <SyntaxHighlighter
+        language={language}
+        style={oneDark}
+        customStyle={{
+          margin: 0,
+          borderRadius: "0.5rem",
+          padding: "1.5rem",
+          paddingTop: "3.5rem",
+          fontSize: "0.875rem",
+          lineHeight: "1.6",
+          border: "1px solid rgba(255, 252, 248, 0.05)",
+        }}
+        showLineNumbers={lineCount > 10}
+        wrapLines={true}
+        wrapLongLines={false}
+      >
+        {code}
+      </SyntaxHighlighter>
+    </div>
+  );
+}

--- a/apps/developers/src/components/code/CopyButton.tsx
+++ b/apps/developers/src/components/code/CopyButton.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useState } from "react";
+import { Check, Copy } from "lucide-react";
+import { trackCodeCopy } from "../../lib/analytics";
+
+interface CopyButtonProps {
+  text: string;
+}
+
+export function CopyButton({ text }: CopyButtonProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    await navigator.clipboard.writeText(text);
+    setCopied(true);
+    trackCodeCopy("code-block");
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <button
+      onClick={handleCopy}
+      className="min-h-11 min-w-11 flex items-center justify-center rounded-lg hover:bg-white/10 transition-colors duration-150 bg-ink/80 backdrop-blur-sm"
+      aria-label="Copy code to clipboard"
+    >
+      {copied ? (
+        <Check className="w-4 h-4 text-accent-green" />
+      ) : (
+        <Copy className="w-4 h-4 text-cream-100/60 hover:text-cream-100 transition-colors" />
+      )}
+    </button>
+  );
+}

--- a/apps/developers/src/components/code/index.ts
+++ b/apps/developers/src/components/code/index.ts
@@ -1,0 +1,2 @@
+export { CodeBlock } from "./CodeBlock";
+export { CopyButton } from "./CopyButton";


### PR DESCRIPTION
## Summary

- Extract shared `CodeBlock` and `CopyButton` components to `apps/developers/src/components/code/`
- Remove **164 lines** of duplicated code across 3 page files
- Update agent documentation to clarify Sisyphus (OpenCode) as primary agent

## Changes

### New Components
- `components/code/CopyButton.tsx` - Shared copy button with analytics
- `components/code/CodeBlock.tsx` - Shared syntax highlighter with line numbers
- `components/code/index.ts` - Barrel export

### Updated Pages
- `app/page.tsx` - Use shared components (-62 lines)
- `app/sdk/page.tsx` - Use shared components (-62 lines)  
- `app/examples/page.tsx` - Use shared components (-55 lines)

### Documentation
- `AGENTS.md` - Clarify Sisyphus as primary agent, Claude Code as backup
- `OPENCODE-PARTNERSHIP.md` - Update partnership model

## Verification
- [x] `bun run typecheck` passes
- [x] `bun run lint` passes (0 warnings)
- [x] Components match original styling exactly