### PR TITLE
fix: standardize docs domain from developers.villa.cash to docs.villa.cash

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ villa/
 ├── apps/
 │   ├── hub/          # Main app (villa.cash)
 │   ├── key/          # Auth iframe (villa.cash/auth)
-│   └── developers/   # Docs (developers.villa.cash)
+│   └── developers/   # Docs (docs.villa.cash)
 ├── packages/
 │   ├── sdk/          # @rockfridrich/villa-sdk
 │   ├── sdk-react/    # React bindings
@@ -130,7 +130,7 @@ Check `packages/ui` first. Add new shared components there.
 | ---------- | --------------------- | ------------ | --------------- |
 | Production | villa.cash            | Base         | Manual `v*` tag |
 | Staging    | beta.villa.cash       | Base Sepolia | Push to `main`  |
-| Developers | developers.villa.cash | -            | Push to `main`  |
+| Docs       | docs.villa.cash       | -            | Push to `main`  |
 
 ## Getting Help
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -10,7 +10,7 @@
 | Domain | Status | Notes |
 |--------|--------|-------|
 | **beta.villa.cash** | Live | Main staging |
-| **developers.villa.cash** | Live | Dev portal |
+| **docs.villa.cash** | Live | Dev portal |
 | **Database** | villa-db (1vCPU/1GB) ~$15/mo | Smallest tier, sufficient |
 | **SDK** | @rockfridrich/villa-sdk@0.1.0 | Published to npm |
 | **Contracts** | Base Sepolia deployed | VillaNicknameResolverV2, BiometricRecoverySignerV2 |
@@ -175,7 +175,7 @@ After biometric testing completes on beta:
 
 Use this to onboard to a new session:
 
-1. **What's deployed?** → beta.villa.cash (staging), developers.villa.cash (docs)
+1. **What's deployed?** → beta.villa.cash (staging), docs.villa.cash (docs)
 2. **Current sprint?** → Sprint 4: SDK screens (P0 done), dev portal nav (P1 in progress)
 3. **Blocked on anything?** → No blockers
 4. **Key decisions made?** → ADR-001: Stay with Porto (multi-chain via wallet linking later)

--- a/apps/developers/public/CLAUDE.txt
+++ b/apps/developers/public/CLAUDE.txt
@@ -167,4 +167,4 @@ After authentication:
 
 - npm: npmjs.com/package/@rockfridrich/villa-sdk-react
 - GitHub: github.com/rockfridrich/villa
-- Docs: developers.villa.cash
+- Docs: docs.villa.cash

--- a/apps/developers/public/llms.txt
+++ b/apps/developers/public/llms.txt
@@ -13,7 +13,7 @@ import { VillaAuth } from '@rockfridrich/villa-sdk-react'
 ```
 
 ## Full Context
-- CLAUDE.txt: https://developers.villa.cash/CLAUDE.txt
+- CLAUDE.txt: https://docs.villa.cash/CLAUDE.txt
 - GitHub: https://raw.githubusercontent.com/rockfridrich/villa/main/apps/developers/public/CLAUDE.txt
 
 ## What It Does

--- a/apps/hub/public/llms.txt
+++ b/apps/hub/public/llms.txt
@@ -51,4 +51,4 @@ type VillaAuthResult =
 ```
 
 ## Docs
-https://developers.villa.cash
+https://docs.villa.cash

--- a/apps/hub/src/app/auth/page.tsx
+++ b/apps/hub/src/app/auth/page.tsx
@@ -26,6 +26,7 @@ const VILLA_ORIGINS = [
   'https://beta.villa.cash',
   'https://dev-1.villa.cash',
   'https://dev-2.villa.cash',
+  'https://docs.villa.cash',
   'https://developers.villa.cash',
   'https://key.villa.cash',
   'https://beta-key.villa.cash',
@@ -43,7 +44,7 @@ const DEV_ORIGINS = [
 ] as const
 
 // Registered external app origins (allowlist for third-party integrations)
-// Apps must register via developers.villa.cash to be added here
+// Apps must register via docs.villa.cash to be added here
 const REGISTERED_APP_ORIGINS = [
   // Lovable.dev (registered partner)
   'https://lovable.dev',

--- a/apps/hub/src/app/dev/page.tsx
+++ b/apps/hub/src/app/dev/page.tsx
@@ -36,7 +36,7 @@ const SERVICES = [
   { name: "Local Hub", url: "http://localhost:3000/api/health" },
   { name: "Staging", url: "https://beta.villa.cash/api/health" },
   { name: "Production", url: "https://villa.cash/api/health" },
-  { name: "Developers", url: "https://developers.villa.cash" },
+  { name: "Docs", url: "https://docs.villa.cash" },
 ];
 
 function StatusBadge({ status }: { status: ServiceStatus["status"] }) {

--- a/apps/key/src/app/auth/page.tsx
+++ b/apps/key/src/app/auth/page.tsx
@@ -95,6 +95,7 @@ const VILLA_ORIGINS = [
   "https://beta.villa.cash",
   "https://dev-1.villa.cash",
   "https://dev-2.villa.cash",
+  "https://docs.villa.cash",
   "https://developers.villa.cash",
   "https://key.villa.cash",
   "https://beta-key.villa.cash",

--- a/bun.lock
+++ b/bun.lock
@@ -1,10 +1,11 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "villa",
       "devDependencies": {
-        "@types/node": "^25.0.3",
+        "@types/node": "25.0.3",
         "@types/react": "18.3.27",
         "prettier": "^3.8.1",
         "turbo": "^2.7.5",
@@ -233,6 +234,7 @@
       "name": "@rockfridrich/villa-sdk-react",
       "version": "0.1.0-alpha.1",
       "devDependencies": {
+        "@rockfridrich/villa-sdk": "workspace:*",
         "@types/react": "^18.2.0",
         "react": "^18.2.0",
         "tsup": "^8.5.1",

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,5 +20,5 @@
 | Resource                                               | Description            |
 | ------------------------------------------------------ | ---------------------- |
 | [CONTRIBUTING.md](../CONTRIBUTING.md)                  | How to contribute      |
-| [developers.villa.cash](https://developers.villa.cash) | Public documentation   |
+| [docs.villa.cash](https://docs.villa.cash) | Public documentation   |
 | [specs/](../specs/)                                    | Feature specifications |

--- a/docs/cloudflare-dns.md
+++ b/docs/cloudflare-dns.md
@@ -43,7 +43,7 @@ Zone Resources: Include → Specific zone → `villa.cash`
 | ----------------------- | ----------- | ---------------- | ------------ |
 | `villa.cash`            | Production  | Release tag `v*` | DigitalOcean |
 | `beta.villa.cash`       | Staging     | Push to `main`   | DigitalOcean |
-| `developers.villa.cash` | Docs Portal | Push to `main`   | DigitalOcean |
+| `docs.villa.cash`       | Docs Portal | Push to `main`   | DigitalOcean |
 | `dev-3.villa.cash`      | Local dev   | ngrok tunnel     | ngrok        |
 
 > **Note:** Preview environments (dev-1, dev-2) were removed in Jan 2026. All PRs now use staging after merge.
@@ -78,7 +78,7 @@ Add these records in CloudFlare DNS settings:
 | CNAME | `@`          | `villa-production-xxxxx.ondigitalocean.app` | Proxied (orange) | Auto |
 | CNAME | `www`        | `villa.cash`                                | Proxied (orange) | Auto |
 | CNAME | `beta`       | `villa-staging-xxxxx.ondigitalocean.app`    | Proxied (orange) | Auto |
-| CNAME | `developers` | `villa-developers-xxxxx.ondigitalocean.app` | Proxied (orange) | Auto |
+| CNAME | `docs`       | `villa-developers-xxxxx.ondigitalocean.app` | Proxied (orange) | Auto |
 | CNAME | `dev-3`      | `[your-ngrok-tunnel].ngrok.io`              | DNS only (grey)  | Auto |
 
 **Important:** Set proxy status to **Proxied (orange cloud)** for CDN, caching, and SSL.

--- a/docs/guides/migration-from-nextauth.md
+++ b/docs/guides/migration-from-nextauth.md
@@ -376,6 +376,6 @@ const user: Identity | null = identity;
 
 ## Need Help?
 
-- [Villa Documentation](https://developers.villa.cash)
+- [Villa Documentation](https://docs.villa.cash)
 - [GitHub Issues](https://github.com/rockfridrich/villa/issues)
 - [Telegram Community](https://t.me/proofofretreat)

--- a/examples/README.md
+++ b/examples/README.md
@@ -36,4 +36,4 @@ All examples require:
 
 ## Documentation
 
-For full SDK documentation, visit [developers.villa.cash](https://developers.villa.cash)
+For full SDK documentation, visit [docs.villa.cash](https://docs.villa.cash)

--- a/examples/nextjs-app/README.md
+++ b/examples/nextjs-app/README.md
@@ -56,7 +56,7 @@ Edit `app/layout.tsx` to customize the Villa SDK config:
 
 For development, you can use any identifier (e.g., `'my-app-dev'`). For production:
 
-1. Visit [developers.villa.cash](https://developers.villa.cash)
+1. Visit [docs.villa.cash](https://docs.villa.cash)
 2. Register your app
 3. Use the assigned App ID
 
@@ -283,7 +283,7 @@ function CustomAuthButton() {
 
 ## Learn More
 
-- [Villa SDK Documentation](https://developers.villa.cash)
+- [Villa SDK Documentation](https://docs.villa.cash)
 - [Villa GitHub](https://github.com/rockfridrich/villa)
 - [Next.js Documentation](https://nextjs.org/docs)
 

--- a/packages/sdk-react/package.json
+++ b/packages/sdk-react/package.json
@@ -31,7 +31,7 @@
     "url": "https://github.com/rockfridrich/villa.git",
     "directory": "packages/sdk-react"
   },
-  "homepage": "https://developers.villa.cash",
+  "homepage": "https://docs.villa.cash",
   "license": "MIT",
   "scripts": {
     "build": "tsup",

--- a/packages/sdk-react/src/context.tsx
+++ b/packages/sdk-react/src/context.tsx
@@ -53,7 +53,8 @@ const TRUSTED_ORIGINS = new Set([
   'https://beta.villa.cash',
   'https://dev-1.villa.cash',
   'https://dev-2.villa.cash',
-  'https://developers.villa.cash',
+  'https://docs.villa.cash',
+  'https://developers.villa.cash', // Legacy, redirect to docs.villa.cash
   'https://localhost:3000',
   'https://localhost:3001',
 ])

--- a/packages/sdk/CLAUDE.txt
+++ b/packages/sdk/CLAUDE.txt
@@ -10,7 +10,7 @@
 - **Packages**: `@rockfridrich/villa-sdk`, `@rockfridrich/villa-sdk-react`
 - **Peer deps**: `viem`, `zod`
 - **Networks**: Base (8453) for production, Base Sepolia (84532) for testing
-- **Docs**: https://developers.villa.cash
+- **Docs**: https://docs.villa.cash
 - **GitHub**: https://github.com/rockfridrich/villa
 
 ## One-Prompt Integration (React)
@@ -362,7 +362,7 @@ After successful authentication:
 | Production | villa.cash | Stable SDK |
 | Construction | construction.villa.cash | Building zone, latest features |
 | Fake Key | fake-key.villa.cash | Test passkeys for community |
-| Developers | developers.villa.cash | Docs + this file |
+| Docs | docs.villa.cash | Docs + this file |
 
 ---
 
@@ -621,7 +621,7 @@ After successful authentication:
 
 ## Links
 
-- Docs: https://developers.villa.cash
+- Docs: https://docs.villa.cash
 - GitHub: https://github.com/rockfridrich/villa
 - npm (SDK): https://www.npmjs.com/package/@rockfridrich/villa-sdk
 - npm (React): https://www.npmjs.com/package/@rockfridrich/villa-sdk-react

--- a/packages/sdk/llms.txt
+++ b/packages/sdk/llms.txt
@@ -51,4 +51,4 @@ type VillaAuthResult =
 ```
 
 ## Docs
-https://developers.villa.cash
+https://docs.villa.cash

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -34,7 +34,7 @@
     "url": "https://github.com/rockfridrich/villa.git",
     "directory": "packages/sdk"
   },
-  "homepage": "https://developers.villa.cash",
+  "homepage": "https://docs.villa.cash",
   "license": "MIT",
   "scripts": {
     "build": "tsup",

--- a/packages/sdk/src/iframe.ts
+++ b/packages/sdk/src/iframe.ts
@@ -17,7 +17,8 @@ const TRUSTED_ORIGINS = [
   "https://beta.villa.cash",
   "https://dev-1.villa.cash",
   "https://dev-2.villa.cash",
-  "https://developers.villa.cash",
+  "https://docs.villa.cash",
+  "https://developers.villa.cash", // Legacy, redirect to docs.villa.cash
   "https://key.villa.cash",
   "https://beta-key.villa.cash",
   "https://localhost:3000",

--- a/scripts/docs/generate-claude-txt.ts
+++ b/scripts/docs/generate-claude-txt.ts
@@ -223,7 +223,7 @@ function generateClaudeTxt(): string {
     `- **Packages**: \`@rockfridrich/villa-sdk\`, \`@rockfridrich/villa-sdk-react\``,
     `- **Peer deps**: \`viem\`, \`zod\``,
     `- **Networks**: Base (8453) for production, Base Sepolia (84532) for testing`,
-    `- **Docs**: https://developers.villa.cash`,
+    `- **Docs**: https://docs.villa.cash`,
     `- **GitHub**: https://github.com/rockfridrich/villa`,
     ``,
     `## One-Prompt Integration (React)`,

--- a/scripts/railway-deploy.sh
+++ b/scripts/railway-deploy.sh
@@ -7,7 +7,7 @@ get_service_info() {
   local app=$1
   case "$app" in
     hub) echo "villa-staging:construction.villa.cash" ;;
-    developers) echo "villa-developers:developers.villa.cash" ;;
+    developers) echo "villa-developers:docs.villa.cash" ;;
     key) echo "villa-key-staging:fake-key.villa.cash" ;;
     *) echo "" ;;
   esac
@@ -18,7 +18,7 @@ usage() {
   echo ""
   echo "Services:"
   echo "  hub         - Deploy to construction.villa.cash"
-  echo "  developers  - Deploy to developers.villa.cash"
+  echo "  developers  - Deploy to docs.villa.cash"
   echo "  key         - Deploy to fake-key.villa.cash"
   echo "  all         - Deploy all services"
   echo ""

--- a/scripts/railway.sh
+++ b/scripts/railway.sh
@@ -315,7 +315,7 @@ cmd_migrate() {
   echo ""
   echo "2. Add custom domains:"
   echo "   railway domain add beta.villa.cash --service villa-staging"
-  echo "   railway domain add developers.villa.cash --service villa-developers"
+  echo "   railway domain add docs.villa.cash --service villa-developers"
   echo "   railway domain add beta-key.villa.cash --service villa-key-staging"
   echo ""
   echo "3. Update CloudFlare DNS to point to Railway"


### PR DESCRIPTION
## Summary

- Standardizes all documentation domain references to canonical `docs.villa.cash` (per domains.json)
- Adds `docs.villa.cash` to TRUSTED_ORIGINS in SDK and auth pages
- Keeps `developers.villa.cash` in TRUSTED_ORIGINS for backwards compatibility during transition

## Changes (22 files)

### SDK Packages
- `packages/sdk/package.json` - homepage URL
- `packages/sdk-react/package.json` - homepage URL  
- `packages/sdk/src/iframe.ts` - TRUSTED_ORIGINS
- `packages/sdk-react/src/context.tsx` - TRUSTED_ORIGINS
- `packages/sdk/CLAUDE.txt` and `llms.txt` - docs links

### Apps
- `apps/developers/public/CLAUDE.txt` and `llms.txt` - docs links
- `apps/hub/src/app/auth/page.tsx` - VILLA_ORIGINS + comment
- `apps/hub/src/app/dev/page.tsx` - service URL
- `apps/hub/public/llms.txt` - docs link
- `apps/key/src/app/auth/page.tsx` - VILLA_ORIGINS

### Documentation
- `docs/README.md`, `docs/cloudflare-dns.md`, `docs/guides/migration-from-nextauth.md`
- `examples/README.md`, `examples/nextjs-app/README.md`
- `CONTRIBUTING.md`, `ROADMAP.md`

### Scripts
- `scripts/railway-deploy.sh`, `scripts/railway.sh`
- `scripts/docs/generate-claude-txt.ts`

## Testing

- [x] `bun run typecheck` passes (20 packages)
- [x] Build succeeds for all affected packages

## Notes

**No breaking changes** - `developers.villa.cash` is kept in trusted origins during the DNS transition period.