### PR TITLE
feat(sdk): Web3 gradient avatar as default

### DIFF
--- a/packages/sdk-react/src/components.tsx
+++ b/packages/sdk-react/src/components.tsx
@@ -2,7 +2,12 @@
 
 import { useCallback } from 'react'
 import { useAuth } from './hooks'
-import { getAvatarUrl, type Identity, type AvatarConfig } from '@rockfridrich/villa-sdk'
+import {
+  getAvatarUrl,
+  getWeb3AvatarStyles,
+  type Identity,
+  type AvatarConfig,
+} from '@rockfridrich/villa-sdk'
 import type { VillaAuthResponse } from './context'
 
 interface VillaAuthProps {
@@ -140,6 +145,27 @@ export function AvatarPreview({
       style={{
         borderRadius: '50%',
         backgroundColor: '#f5f5f5',
+      }}
+    />
+  )
+}
+
+interface Web3AvatarProps {
+  address: string
+  size?: number
+  className?: string
+}
+
+export function Web3Avatar({ address, size = 48, className = '' }: Web3AvatarProps) {
+  const styles = getWeb3AvatarStyles(address)
+
+  return (
+    <div
+      className={className}
+      style={{
+        width: size,
+        height: size,
+        ...styles,
       }}
     />
   )

--- a/packages/sdk-react/src/index.ts
+++ b/packages/sdk-react/src/index.ts
@@ -22,7 +22,7 @@ export type {
 export { useIdentity, useAuth, useVillaConfig } from "./hooks";
 
 // Components
-export { VillaAuth, Avatar, AvatarPreview } from "./components";
+export { VillaAuth, Avatar, AvatarPreview, Web3Avatar } from "./components";
 
 // Re-export types from core SDK
 export type {

--- a/packages/sdk/src/avatar.ts
+++ b/packages/sdk/src/avatar.ts
@@ -1,57 +1,130 @@
 /**
- * Avatar URL Generation
+ * Avatar Generation
  *
- * Generates deterministic avatar URLs using DiceBear API.
- * No fetch required - just returns the URL for client-side rendering.
+ * Supports two avatar types:
+ * 1. Web3 gradient avatars (default) - beautiful gradients from wallet address
+ * 2. DiceBear avatars - character-based avatars
  */
 
-import type { AvatarConfig } from './types'
+import type { AvatarConfig, AvatarStyle } from "./types";
 
-const DICEBEAR_API = 'https://api.dicebear.com/7.x'
+const DICEBEAR_API = "https://api.dicebear.com/7.x";
 
 /**
- * Generates a deterministic avatar URL from a seed
- *
- * @param seed - Seed for deterministic generation (address, nickname, etc)
- * @param config - Optional avatar configuration
- * @returns URL to DiceBear SVG avatar
- *
- * @example
- * const url = getAvatarUrl('alice')
- * // => 'https://api.dicebear.com/7.x/adventurer/svg?seed=alice'
- *
- * const url = getAvatarUrl('bob', { style: 'bottts' })
- * // => 'https://api.dicebear.com/7.x/bottts/svg?seed=bob'
+ * Generate gradient colors from an Ethereum address.
+ * Based on web3-avatar by JackHamer09.
+ * @see https://github.com/JackHamer09/web3-avatar
+ */
+export function getWeb3GradientColors(address: string): string[] {
+  const seedArr = address.match(/.{1,7}/g)?.splice(0, 5);
+  const colors: string[] = [];
+
+  seedArr?.forEach((seed) => {
+    let hash = 0;
+    for (let i = 0; i < seed.length; i += 1) {
+      hash = seed.charCodeAt(i) + ((hash << 5) - hash);
+      hash = hash & hash;
+    }
+    const rgb = [0, 0, 0];
+    for (let i = 0; i < 3; i += 1) {
+      const value = (hash >> (i * 8)) & 255;
+      rgb[i] = value;
+    }
+    colors.push(`rgb(${rgb[0]}, ${rgb[1]}, ${rgb[2]})`);
+  });
+
+  return colors;
+}
+
+/**
+ * Generate CSS for a web3 gradient avatar.
+ * Can be applied as inline styles to any element.
+ */
+export function getWeb3AvatarStyles(address: string): {
+  backgroundColor: string;
+  backgroundImage: string;
+  borderRadius: string;
+  boxShadow: string;
+} {
+  const colors = getWeb3GradientColors(address);
+  return {
+    backgroundColor: colors[0] || "#ccc",
+    backgroundImage: `
+      radial-gradient(at 66% 77%, ${colors[1]} 0px, transparent 50%),
+      radial-gradient(at 29% 97%, ${colors[2]} 0px, transparent 50%),
+      radial-gradient(at 99% 86%, ${colors[3]} 0px, transparent 50%),
+      radial-gradient(at 29% 88%, ${colors[4]} 0px, transparent 50%)
+    `.trim(),
+    borderRadius: "50%",
+    boxShadow: "inset 0 0 0 1px rgba(0, 0, 0, 0.1)",
+  };
+}
+
+/**
+ * Generate a data URI for a web3 gradient avatar SVG.
+ * Useful when you need a URL instead of inline styles.
+ */
+export function getWeb3AvatarDataUri(address: string, size = 100): string {
+  const colors = getWeb3GradientColors(address);
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="${size}" height="${size}" viewBox="0 0 ${size} ${size}">
+    <defs>
+      <radialGradient id="g1" cx="66%" cy="77%"><stop offset="0%" stop-color="${colors[1]}"/><stop offset="50%" stop-color="transparent"/></radialGradient>
+      <radialGradient id="g2" cx="29%" cy="97%"><stop offset="0%" stop-color="${colors[2]}"/><stop offset="50%" stop-color="transparent"/></radialGradient>
+      <radialGradient id="g3" cx="99%" cy="86%"><stop offset="0%" stop-color="${colors[3]}"/><stop offset="50%" stop-color="transparent"/></radialGradient>
+      <radialGradient id="g4" cx="29%" cy="88%"><stop offset="0%" stop-color="${colors[4]}"/><stop offset="50%" stop-color="transparent"/></radialGradient>
+    </defs>
+    <circle cx="${size / 2}" cy="${size / 2}" r="${size / 2}" fill="${colors[0]}"/>
+    <circle cx="${size / 2}" cy="${size / 2}" r="${size / 2}" fill="url(#g1)"/>
+    <circle cx="${size / 2}" cy="${size / 2}" r="${size / 2}" fill="url(#g2)"/>
+    <circle cx="${size / 2}" cy="${size / 2}" r="${size / 2}" fill="url(#g3)"/>
+    <circle cx="${size / 2}" cy="${size / 2}" r="${size / 2}" fill="url(#g4)"/>
+  </svg>`;
+
+  return `data:image/svg+xml,${encodeURIComponent(svg)}`;
+}
+
+/**
+ * Get avatar URL - supports both web3 gradients and DiceBear styles.
+ * Default is "web3" which generates a gradient from the wallet address.
  */
 export function getAvatarUrl(
   seed: string,
   config?: Partial<AvatarConfig>
 ): string {
-  const style = config?.style || 'adventurer'
-  const params = new URLSearchParams({ seed })
+  const style = config?.style || "web3";
 
-  // Add gender preference if provided and style supports it
-  if (config?.gender) {
-    params.set('gender', config.gender)
+  // Web3 gradient avatar (default)
+  if (style === "web3") {
+    return getWeb3AvatarDataUri(seed);
   }
 
-  return `${DICEBEAR_API}/${style}/svg?${params.toString()}`
+  // DiceBear avatar
+  const params = new URLSearchParams({ seed });
+  if (config?.gender) {
+    params.set("gender", config.gender);
+  }
+
+  return `${DICEBEAR_API}/${style}/svg?${params.toString()}`;
 }
 
 /**
- * Creates a complete AvatarConfig from partial input
- *
- * @param seed - Seed for avatar generation
- * @param partial - Partial avatar configuration
- * @returns Complete AvatarConfig with defaults
+ * Creates a complete AvatarConfig with defaults.
+ * Default style is "web3" (gradient avatar).
  */
 export function createAvatarConfig(
   seed: string,
   partial?: Partial<AvatarConfig>
 ): AvatarConfig {
   return {
-    style: partial?.style || 'adventurer',
+    style: partial?.style || "web3",
     seed,
     gender: partial?.gender,
-  }
+  };
+}
+
+/**
+ * Get list of all available avatar styles.
+ */
+export function getAvatarStyles(): readonly AvatarStyle[] {
+  return ["web3", "lorelei", "adventurer", "avataaars", "bottts", "thumbs"];
 }

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -30,7 +30,14 @@ export type {
 
 // Core utilities
 export { resolveEns, reverseEns } from "./ens";
-export { getAvatarUrl, createAvatarConfig } from "./avatar";
+export {
+  getAvatarUrl,
+  createAvatarConfig,
+  getAvatarStyles,
+  getWeb3GradientColors,
+  getWeb3AvatarStyles,
+  getWeb3AvatarDataUri,
+} from "./avatar";
 
 // Auth utilities
 export { signIn, signOut, isAuthenticated, getIdentity } from "./auth";

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -15,8 +15,9 @@ export interface Identity {
   avatar?: AvatarConfig;
 }
 
-/** Supported avatar styles (DiceBear collection names) */
+/** Supported avatar styles */
 export type AvatarStyle =
+  | "web3" // Default: gradient avatar from wallet address
   | "lorelei"
   | "adventurer"
   | "avataaars"
@@ -25,11 +26,11 @@ export type AvatarStyle =
 
 /** Avatar configuration for deterministic generation */
 export interface AvatarConfig {
-  /** DiceBear style name */
+  /** Avatar style - "web3" (default gradient) or DiceBear styles */
   style: AvatarStyle;
   /** Seed for deterministic generation (usually address or nickname) */
   seed: string;
-  /** Optional gender preference for gendered styles */
+  /** Optional gender preference for gendered DiceBear styles */
   gender?: "male" | "female" | "other";
 }
 


### PR DESCRIPTION
## Summary
- Changes default avatar from DiceBear to Web3 gradient avatars
- Beautiful gradients generated deterministically from wallet address
- Based on [web3-avatar](https://github.com/JackHamer09/web3-avatar) by JackHamer09

## Changes

### SDK (`@rockfridrich/villa-sdk`)
- New `AvatarStyle`: `"web3"` (now default)
- New exports:
  - `getWeb3GradientColors(address)` - get gradient colors array
  - `getWeb3AvatarStyles(address)` - get CSS styles for inline rendering
  - `getWeb3AvatarDataUri(address)` - get data URI for img src
  - `getAvatarStyles()` - list all available styles

### React SDK (`@rockfridrich/villa-sdk-react`)
- New `<Web3Avatar address="0x..." />` component
- Existing `<Avatar>` now defaults to web3 style

## Breaking Changes
**Default avatar style changed**: `"adventurer"` → `"web3"`

Existing users who want DiceBear avatars need to explicitly set style:
```typescript
const url = getAvatarUrl(address, { style: 'adventurer' })
```

## No New Dependencies
Pure JS implementation - zero additional packages.

## Preview
See live demo: https://web3-avatar.netlify.app/

## Related
- Closes #61 (seeded avatar system)