### PR TITLE
feat(sdk): add villa.settings() popup for profile editing

### DIFF
--- a/apps/key/src/app/settings/page.tsx
+++ b/apps/key/src/app/settings/page.tsx
@@ -1,0 +1,306 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import { useCallback, useEffect, useRef, useMemo, useState, Suspense } from "react";
+import { motion } from "framer-motion";
+import { Loader2, LogOut, Check, X, User, Palette } from "lucide-react";
+import { Web3Avatar, getGradientColors } from "@/lib/web3-avatar";
+
+const HUB_API_URL = process.env.NEXT_PUBLIC_HUB_API_URL || "https://beta.villa.cash";
+
+const AVATAR_STYLES = ["web3", "lorelei", "adventurer", "avataaars", "bottts", "thumbs"] as const;
+
+interface ProfileData {
+  nickname: string;
+  avatar?: { style: string; seed: string };
+}
+
+const VILLA_ORIGINS = [
+  "https://villa.cash",
+  "https://www.villa.cash",
+  "https://beta.villa.cash",
+  "https://construction.villa.cash",
+  "https://docs.villa.cash",
+  "https://key.villa.cash",
+] as const;
+
+const DEV_ORIGINS = [
+  "https://local.villa.cash",
+  "https://localhost",
+  "https://localhost:3000",
+  "http://localhost:3000",
+] as const;
+
+function isAllowedOrigin(origin: string): boolean {
+  return (
+    VILLA_ORIGINS.includes(origin as (typeof VILLA_ORIGINS)[number]) ||
+    DEV_ORIGINS.includes(origin as (typeof DEV_ORIGINS)[number]) ||
+    origin.endsWith(".lovable.dev") ||
+    origin.endsWith(".vercel.app")
+  );
+}
+
+function getValidatedParentOrigin(queryOrigin: string | null): string | null {
+  if (typeof document !== "undefined" && document.referrer) {
+    try {
+      const referrerUrl = new URL(document.referrer);
+      if (isAllowedOrigin(referrerUrl.origin)) {
+        return referrerUrl.origin;
+      }
+    } catch {}
+  }
+  if (queryOrigin && isAllowedOrigin(queryOrigin)) {
+    return queryOrigin;
+  }
+  return null;
+}
+
+function isInPopup(): boolean {
+  if (typeof window === "undefined") return false;
+  const params = new URLSearchParams(window.location.search);
+  return params.get("mode") === "popup" || (window.opener != null && window.opener !== window);
+}
+
+function SettingsContent() {
+  const searchParams = useSearchParams();
+  const hasNotifiedReady = useRef(false);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [profile, setProfile] = useState<ProfileData | null>(null);
+  const [selectedStyle, setSelectedStyle] = useState<string>("web3");
+  const [nickname, setNickname] = useState("");
+  const [nicknameError, setNicknameError] = useState<string | null>(null);
+
+  const queryOrigin = searchParams.get("origin");
+  const address = searchParams.get("address");
+  const targetOrigin = useMemo(() => getValidatedParentOrigin(queryOrigin), [queryOrigin]);
+  const inPopup = useMemo(() => isInPopup(), []);
+
+  const postToParent = useCallback(
+    (message: Record<string, unknown>) => {
+      if (!inPopup) return;
+      if (!targetOrigin) return;
+      const target = window.opener;
+      if (target) {
+        target.postMessage(message, targetOrigin);
+      }
+    },
+    [targetOrigin, inPopup],
+  );
+
+  useEffect(() => {
+    if (!hasNotifiedReady.current) {
+      hasNotifiedReady.current = true;
+      postToParent({ type: "VILLA_READY" });
+    }
+  }, [postToParent]);
+
+  useEffect(() => {
+    async function loadProfile() {
+      if (!address) {
+        setLoading(false);
+        return;
+      }
+      try {
+        const res = await fetch(`${HUB_API_URL}/api/profile/${address.toLowerCase()}`);
+        if (res.ok) {
+          const data = await res.json();
+          setProfile(data);
+          setNickname(data.nickname || "");
+          setSelectedStyle(data.avatar?.style || "web3");
+        }
+      } catch {}
+      setLoading(false);
+    }
+    loadProfile();
+  }, [address]);
+
+  const handleSave = async () => {
+    if (!address || !nickname.trim()) return;
+
+    setSaving(true);
+    setNicknameError(null);
+
+    try {
+      const res = await fetch(`${HUB_API_URL}/api/profile`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          address,
+          nickname: nickname.trim(),
+          avatar: { style: selectedStyle, seed: address },
+        }),
+      });
+
+      if (res.ok) {
+        const updated = await res.json();
+        const identity = {
+          address,
+          nickname: updated.nickname,
+          avatar: { style: selectedStyle, seed: address },
+        };
+        postToParent({ type: "VILLA_AUTH_SUCCESS", payload: { identity } });
+        if (inPopup) {
+          setTimeout(() => window.close(), 300);
+        }
+      } else if (res.status === 409) {
+        setNicknameError("Nickname already taken");
+      } else {
+        setNicknameError("Failed to save");
+      }
+    } catch {
+      setNicknameError("Network error");
+    }
+    setSaving(false);
+  };
+
+  const handleCancel = () => {
+    postToParent({ type: "VILLA_AUTH_CANCEL" });
+    if (inPopup) {
+      setTimeout(() => window.close(), 300);
+    }
+  };
+
+  const handleLogout = () => {
+    postToParent({ type: "VILLA_AUTH_ERROR", payload: { error: "User logged out", code: "LOGOUT" } });
+    if (inPopup) {
+      setTimeout(() => window.close(), 300);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-[#FFFDF8] flex items-center justify-center">
+        <Loader2 className="w-8 h-8 animate-spin text-[#FFE047]" />
+      </div>
+    );
+  }
+
+  if (!address) {
+    return (
+      <div className="min-h-screen bg-[#FFFDF8] flex items-center justify-center p-4">
+        <div className="text-center">
+          <p className="text-[#0D0D17]/60">Missing address parameter</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-[#FFFDF8] flex flex-col">
+      {/* Header */}
+      <div className="p-4 border-b border-black/5 flex items-center justify-between">
+        <h1 className="font-serif text-xl text-[#0D0D17]">Settings</h1>
+        <button onClick={handleCancel} className="p-2 hover:bg-black/5 rounded-lg transition-colors">
+          <X className="w-5 h-5 text-[#0D0D17]/60" />
+        </button>
+      </div>
+
+      <div className="flex-1 p-6 space-y-8 overflow-auto">
+        {/* Avatar Section */}
+        <section className="space-y-4">
+          <div className="flex items-center gap-2 text-[#0D0D17]/60">
+            <Palette className="w-4 h-4" />
+            <span className="text-sm font-medium uppercase tracking-wider">Avatar</span>
+          </div>
+
+          {/* Current Avatar */}
+          <div className="flex justify-center">
+            {selectedStyle === "web3" ? (
+              <Web3Avatar address={address} size={96} className="ring-4 ring-[#FFE047]/30" />
+            ) : (
+              <img
+                src={`https://api.dicebear.com/7.x/${selectedStyle}/svg?seed=${address}`}
+                alt="Avatar"
+                className="w-24 h-24 rounded-full ring-4 ring-[#FFE047]/30"
+              />
+            )}
+          </div>
+
+          {/* Style Picker */}
+          <div className="grid grid-cols-3 gap-3">
+            {AVATAR_STYLES.map((style) => (
+              <button
+                key={style}
+                onClick={() => setSelectedStyle(style)}
+                className={`p-3 rounded-xl border-2 transition-all ${
+                  selectedStyle === style
+                    ? "border-[#FFE047] bg-[#FFE047]/10"
+                    : "border-transparent bg-black/5 hover:bg-black/10"
+                }`}
+              >
+                {style === "web3" ? (
+                  <Web3Avatar address={address} size={48} className="mx-auto" />
+                ) : (
+                  <img
+                    src={`https://api.dicebear.com/7.x/${style}/svg?seed=${address}`}
+                    alt={style}
+                    className="w-12 h-12 mx-auto rounded-full"
+                  />
+                )}
+                <p className="text-xs text-center mt-2 text-[#0D0D17]/60 capitalize">{style}</p>
+              </button>
+            ))}
+          </div>
+        </section>
+
+        {/* Nickname Section */}
+        <section className="space-y-4">
+          <div className="flex items-center gap-2 text-[#0D0D17]/60">
+            <User className="w-4 h-4" />
+            <span className="text-sm font-medium uppercase tracking-wider">Nickname</span>
+          </div>
+
+          <div className="space-y-2">
+            <input
+              type="text"
+              value={nickname}
+              onChange={(e) => {
+                setNickname(e.target.value);
+                setNicknameError(null);
+              }}
+              placeholder="Enter nickname"
+              className="w-full px-4 py-3 rounded-xl border border-black/10 bg-white focus:outline-none focus:ring-2 focus:ring-[#FFE047] text-[#0D0D17]"
+            />
+            {nicknameError && <p className="text-sm text-red-500">{nicknameError}</p>}
+            <p className="text-xs text-[#0D0D17]/40">3-30 characters, letters, numbers, underscores</p>
+          </div>
+        </section>
+      </div>
+
+      {/* Footer Actions */}
+      <div className="p-4 border-t border-black/5 space-y-3">
+        <button
+          onClick={handleSave}
+          disabled={saving || !nickname.trim()}
+          className="w-full py-4 bg-[#FFE047] text-[#0D0D17] font-medium rounded-xl hover:bg-[#FDD835] disabled:opacity-50 disabled:cursor-not-allowed transition-colors flex items-center justify-center gap-2"
+        >
+          {saving ? <Loader2 className="w-5 h-5 animate-spin" /> : <Check className="w-5 h-5" />}
+          Save Changes
+        </button>
+
+        <button
+          onClick={handleLogout}
+          className="w-full py-3 text-red-500 font-medium rounded-xl hover:bg-red-50 transition-colors flex items-center justify-center gap-2"
+        >
+          <LogOut className="w-4 h-4" />
+          Sign Out
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default function SettingsPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="min-h-screen bg-[#FFFDF8] flex items-center justify-center">
+          <Loader2 className="w-8 h-8 animate-spin text-[#FFE047]" />
+        </div>
+      }
+    >
+      <SettingsContent />
+    </Suspense>
+  );
+}

--- a/apps/key/src/lib/web3-avatar.tsx
+++ b/apps/key/src/lib/web3-avatar.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+interface Web3AvatarProps {
+  address: string;
+  size?: number;
+  className?: string;
+}
+
+/** Generate gradient colors from Ethereum address bytes */
+export function getGradientColors(address: string): [string, string] {
+  const hex = address.toLowerCase().replace("0x", "");
+
+  const hue1 = parseInt(hex.slice(0, 6), 16) % 360;
+  const hue2 = parseInt(hex.slice(6, 12), 16) % 360;
+  const sat1 = 60 + (parseInt(hex.slice(12, 14), 16) % 30);
+  const sat2 = 60 + (parseInt(hex.slice(14, 16), 16) % 30);
+  const light1 = 50 + (parseInt(hex.slice(16, 18), 16) % 20);
+  const light2 = 50 + (parseInt(hex.slice(18, 20), 16) % 20);
+
+  return [
+    `hsl(${hue1}, ${sat1}%, ${light1}%)`,
+    `hsl(${hue2}, ${sat2}%, ${light2}%)`,
+  ];
+}
+
+function getGradientAngle(address: string): number {
+  const hex = address.toLowerCase().replace("0x", "");
+  return parseInt(hex.slice(20, 24), 16) % 360;
+}
+
+export function Web3Avatar({ address, size = 48, className = "" }: Web3AvatarProps) {
+  const [color1, color2] = getGradientColors(address);
+  const angle = getGradientAngle(address);
+
+  return (
+    <div
+      className={`rounded-full ${className}`}
+      style={{
+        width: size,
+        height: size,
+        background: `linear-gradient(${angle}deg, ${color1}, ${color2})`,
+      }}
+      aria-label={`Avatar for ${address.slice(0, 6)}...${address.slice(-4)}`}
+    />
+  );
+}

--- a/packages/sdk/src/iframe/types.ts
+++ b/packages/sdk/src/iframe/types.ts
@@ -42,6 +42,7 @@ export type VillaErrorCode =
   | 'AUTH_FAILED'
   | 'PASSKEY_ERROR'
   | 'CONSENT_REQUIRED'
+  | 'LOGOUT'
 
 /**
  * Bridge configuration

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -16,7 +16,7 @@ export {
   syncProfileToTinyCloud,
   loadProfileFromTinyCloud,
 } from "./simple";
-export type { VillaUser, SimpleSignInOptions } from "./simple";
+export type { VillaUser, SimpleSignInOptions, SettingsResult } from "./simple";
 
 // Main SDK client (advanced)
 export { Villa } from "./client";

--- a/packages/sdk/src/simple.ts
+++ b/packages/sdk/src/simple.ts
@@ -49,10 +49,17 @@ export interface SimpleSignInOptions {
   timeout?: number;
 }
 
+export interface SettingsResult {
+  avatar?: { style: string; seed: string };
+  nickname?: string;
+  loggedOut?: boolean;
+}
+
 interface VillaInstance {
   user: VillaUser | null;
   signIn: (options?: SimpleSignInOptions) => Promise<VillaUser>;
   signOut: () => void;
+  settings: () => Promise<SettingsResult>;
   onAuthChange: (callback: (user: VillaUser | null) => void) => () => void;
   config: (options: Partial<VillaConfig>) => void;
 }
@@ -149,6 +156,54 @@ function signOut() {
   notifyListeners();
 }
 
+async function openSettings(): Promise<SettingsResult> {
+  init();
+
+  if (!_user) {
+    throw new Error("Must be signed in to open settings");
+  }
+
+  return new Promise((resolve, reject) => {
+    const bridge = new VillaBridge({
+      appId: _config.appId,
+      network: _config.network,
+      timeout: 10 * 60 * 1000,
+    });
+
+    bridge.on("success", (identity) => {
+      const user = identityToUser(identity);
+      _user = user;
+
+      saveSession({
+        identity,
+        expiresAt: Date.now() + SESSION_DURATION_MS,
+        isValid: true,
+      });
+
+      notifyListeners();
+      resolve({
+        avatar: identity.avatar,
+        nickname: identity.nickname,
+      });
+    });
+
+    bridge.on("cancel", () => {
+      resolve({});
+    });
+
+    bridge.on("error", (error, code) => {
+      if (code === "LOGOUT") {
+        signOut();
+        resolve({ loggedOut: true });
+      } else {
+        reject(new Error(error));
+      }
+    });
+
+    bridge.open(["settings"]).catch(reject);
+  });
+}
+
 function onAuthChange(callback: (user: VillaUser | null) => void): () => void {
   init();
   _listeners.add(callback);
@@ -167,6 +222,7 @@ export const villa: VillaInstance = {
   },
   signIn,
   signOut,
+  settings: openSettings,
   onAuthChange,
   config: configure,
 };


### PR DESCRIPTION
## Summary

Adds a `villa.settings()` popup for users to edit their profile (avatar + nickname) and sign out.

### Changes

**SDK (`packages/sdk/`)**
- Add `settings()` method to simple API
- Add `SettingsResult` type export
- Add `LOGOUT` error code to bridge types

**Key App (`apps/key/`)**
- New `/settings` page with:
  - Avatar style picker (web3 gradient + 5 DiceBear styles)
  - Nickname editor with validation
  - Logout button
  - postMessage communication back to parent app
- New `Web3Avatar` component for gradient avatars from wallet address

### Architecture

```
SDK                              key.villa.cash
===                              ==============
villa.settings() ────────────► /settings popup
                                  │
                                  ├─ Avatar picker
                                  ├─ Nickname editor
                                  └─ Logout button
                                       │
VILLA_AUTH_SUCCESS ◄─────────────────┘ (on save)
VILLA_AUTH_ERROR(LOGOUT) ◄───────────┘ (on logout)
```

Closes #64