### PR TITLE
Docker selective COPY + expanded .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -58,10 +58,45 @@ vitest.config*
 .github
 .do
 
+# OpenCode development
+.opencode
+.1code
+
 # Claude development
 .claude
 .beads
 costs
 
+# Specs and documentation
+specs
+
 # Examples (not needed for tests)
 examples
+
+# Development scripts
+scripts
+
+# Test directories for production builds
+tests
+*.spec.ts
+*.test.ts
+
+# Additional dev configs
+.pre-commit-config.yaml
+.gitleaks.toml
+.gitmodules
+typedoc.json
+codecov.yml
+CONTRIBUTING.md
+SECURITY.md
+OPENCODE-PARTNERSHIP.md
+AGENT_COORDINATION.md
+AGENTS.md
+
+# Development Docker files
+docker-compose*.yml
+Dockerfile.dev
+Dockerfile.test
+
+# Development certificates
+certificates

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,9 +22,15 @@ RUN apk add --no-cache nodejs npm
 WORKDIR /app
 
 COPY --from=deps /app/node_modules ./node_modules/
-COPY --from=deps /app/apps ./apps/
-COPY --from=deps /app/packages ./packages/
-COPY . .
+
+# Copy workspace files  
+COPY package.json bun.lock turbo.json ./
+
+# Copy hub-specific files
+COPY apps/hub ./apps/hub/
+
+# Copy shared packages
+COPY packages ./packages/
 
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV NODE_ENV=production

--- a/apps/developers/Dockerfile
+++ b/apps/developers/Dockerfile
@@ -26,9 +26,15 @@ RUN apk add --no-cache nodejs npm
 WORKDIR /app
 
 COPY --from=deps /app/node_modules ./node_modules/
-COPY --from=deps /app/apps ./apps/
-COPY --from=deps /app/packages ./packages/
-COPY . .
+
+# Copy workspace files  
+COPY package.json bun.lock turbo.json ./
+
+# Copy developers-specific files
+COPY apps/developers ./apps/developers/
+
+# Copy shared packages
+COPY packages ./packages/
 
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV NODE_ENV=production

--- a/apps/key/Dockerfile
+++ b/apps/key/Dockerfile
@@ -22,8 +22,15 @@ RUN apk add --no-cache nodejs npm
 WORKDIR /app
 
 COPY --from=deps /app/node_modules ./node_modules/
-COPY --from=deps /app/apps ./apps/
-COPY . .
+
+# Copy workspace files  
+COPY package.json bun.lock turbo.json ./
+
+# Copy key-specific files
+COPY apps/key ./apps/key/
+
+# Copy shared packages
+COPY packages ./packages/
 
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV NODE_ENV=production


### PR DESCRIPTION
## Summary

Replace blanket `COPY . .` with targeted copies in all Dockerfiles and expand .dockerignore to exclude development directories.

### Changes

**Dockerfiles Updated:**
- Root `Dockerfile` (hub service)
- `apps/key/Dockerfile` 
- `apps/developers/Dockerfile`

**Selective Copy Strategy:**
- Copy workspace files: `package.json`, `bun.lock`, `turbo.json`
- Copy service-specific app directory only
- Copy shared `packages/` directory

**Expanded .dockerignore:**
- OpenCode development: `.opencode`, `.1code`
- Claude development: `.claude`, `.beads`
- Documentation: `specs`
- Development tools: `scripts`, `tests`, `certificates`
- Development configs and Docker files

### Benefits

- **Faster Docker builds** - smaller context size
- **Better caching efficiency** - more granular layer invalidation
- **Reduced image sizes** - excludes unnecessary development files
- **Better security** - prevents accidental inclusion of sensitive dev files

### Testing

- ✅ All required files verified to exist
- ✅ Build dependencies resolved correctly  
- ✅ Typecheck and lint passing
- 🔄 Full E2E tests running in CI

### Impact

This change optimizes the Docker build process without affecting runtime functionality. All services will build with smaller contexts and better caching.