### PR TITLE
fix(docs): populate build metadata in health endpoint

### DIFF
--- a/apps/developers/Dockerfile
+++ b/apps/developers/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1.4
 # Production Dockerfile for Villa Developers Portal
 
-ARG CACHE_BUST=1
+ARG CACHE_BUST=2
 FROM oven/bun:1-alpine AS deps
 RUN apk add --no-cache libc6-compat git
 WORKDIR /app
@@ -34,6 +34,16 @@ COPY . .
 
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV NODE_ENV=production
+ARG BUILD_TIME
+
+ARG NEXT_PUBLIC_ENV=production
+ARG RAILWAY_GIT_COMMIT_SHA
+ARG NEXT_PUBLIC_VERSION=0.1.0
+
+ENV NEXT_PUBLIC_ENV=$NEXT_PUBLIC_ENV
+ENV NEXT_PUBLIC_GIT_SHA=$RAILWAY_GIT_COMMIT_SHA
+ENV NEXT_PUBLIC_VERSION=$NEXT_PUBLIC_VERSION
+ENV NEXT_PUBLIC_BUILD_TIME=$BUILD_TIME
 
 # Build developers app using turbo
 RUN bun turbo run build --filter=@villa/developers


### PR DESCRIPTION
## Summary
- Add build-time environment variables to developers Dockerfile
- Include BUILD_TIME, NEXT_PUBLIC_VERSION, NEXT_PUBLIC_GIT_SHA, NEXT_PUBLIC_ENV
- Increment cache bust to trigger Railway rebuild

## Problem
docs.villa.cash/api/health was returning "unknown" for all build metadata fields because the Dockerfile wasn't setting the required environment variables at build time.

## Solution
Updated `apps/developers/Dockerfile` to match the pattern used in the main hub Dockerfile:
- Added ARG declarations for build metadata
- Set ENV variables from ARG values
- Incremented cache bust to force Railway rebuild

## Test Plan
- [x] Commit pushed to trigger deploy
- [ ] Wait for Railway deployment to complete
- [ ] Verify: `curl https://docs.villa.cash/api/health | jq .`
- [ ] Confirm version, sha, and build time are populated

## Related
Fixes villa-fod task

🤖 Generated with [Claude Code](https://claude.com/claude-code)