### PR TITLE
fix(hub): persist nickname edit + bump v0.3.0-rc.2

### DIFF
--- a/apps/developers/package.json
+++ b/apps/developers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@villa/developers",
-  "version": "0.2.0",
+  "version": "0.3.0-rc.2",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3002",

--- a/apps/hub/package.json
+++ b/apps/hub/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@villa/hub",
-  "version": "0.2.0",
+  "version": "0.3.0-rc.2",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/apps/hub/src/app/home/page.tsx
+++ b/apps/hub/src/app/home/page.tsx
@@ -202,13 +202,22 @@ export default function HomePage() {
     setIsSaving(true);
     setEditError(null);
 
-    // Update via store
-    const success = updateProfile(result.data);
+    try {
+      // Persist to backend
+      await fetch("/api/profile", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          address: identity.address,
+          newNickname: result.data,
+        }),
+      });
 
-    if (success) {
+      // Update local store
+      updateProfile(result.data);
       setIsEditing(false);
       setEditValue("");
-    } else {
+    } catch {
       setEditError("Failed to update nickname");
     }
     setIsSaving(false);

--- a/apps/key/package.json
+++ b/apps/key/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@villa/key",
-  "version": "0.2.0",
+  "version": "0.3.0-rc.2",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/bun.lock
+++ b/bun.lock
@@ -37,7 +37,7 @@
     },
     "apps/developers": {
       "name": "@villa/developers",
-      "version": "0.2.0",
+      "version": "0.3.0-rc.2",
       "dependencies": {
         "@monaco-editor/react": "^4.7.0",
         "@rockfridrich/villa-sdk": "workspace:*",
@@ -68,7 +68,7 @@
     },
     "apps/hub": {
       "name": "@villa/hub",
-      "version": "0.2.0",
+      "version": "0.3.0-rc.2",
       "dependencies": {
         "@dicebear/adventurer": "^9.2.4",
         "@dicebear/avataaars": "^9.2.4",
@@ -133,7 +133,7 @@
     },
     "apps/key": {
       "name": "@villa/key",
-      "version": "0.2.0",
+      "version": "0.3.0-rc.2",
       "dependencies": {
         "@villa/ui": "workspace:*",
         "clsx": "^2.1.0",


### PR DESCRIPTION
## Summary
- **Nickname persistence**: Inline nickname edit on home page now calls `PATCH /api/profile` to persist to database (was local-only Zustand store)
- **Version bump**: All apps bumped to `0.3.0-rc.2`

## Test plan
- [ ] Typecheck + lint pass (confirmed)
- [ ] Edit nickname on home page → verify network tab shows PATCH call
- [ ] After deploy: health endpoints report `0.3.0-rc.2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)